### PR TITLE
Add rollback option to Snowfakery data load

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -91,6 +91,7 @@ flows:
                 options:
                     recipe: datasets/sample-data/sample_data.yml
                     drop_missing_schema: true
+                    enable_rollback: true
             2:
                 task: execute_anon
                 options:
@@ -127,6 +128,7 @@ flows:
                 options:
                     recipe: datasets/community-sample-data/community_sample_data.yml
                     drop_missing_schema: true
+                    enable_rollback: true
                     
 tasks:
     robot:

--- a/datasets/sample-data/sample_appointment_data.yml
+++ b/datasets/sample-data/sample_appointment_data.yml
@@ -532,10 +532,10 @@
 # ── Date variables ─────────────────────────────────────────────────────────────
 
 - var: last_friday
-  value: ${{ today + relativedelta(day=today.day-7, weekday=4) }}
+  value: ${{ today + relativedelta(days=-7, weekday=4) }}
 
 - var: upcoming_friday
-  value: ${{ today + relativedelta(weekday=4) }}
+  value: ${{ today + relativedelta(days=1, weekday=4) }}
 
 # =============================================================================
 # PAST APPOINTMENT — Last Friday at 9:30am PT (Completed)


### PR DESCRIPTION
# Changes
- Snowfakery data is now rolled back if an error occurs during data load
- A separate unreported issue with relative dates in the appointment data was also fixed

# Issues Closed
#9 